### PR TITLE
Feat: Add GitHub Actions workflow for GH Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,35 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main # Or your default branch
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Allow write access to repository for gh-pages branch creation/update
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18' # Or your preferred Node.js version
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build project
+        run: npm run build
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }} # Pass API key as secret
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist


### PR DESCRIPTION
- Configured Vite for GitHub Pages (base path, HTML cleanup, CSS import).
- Added a GitHub Actions workflow (`.github/workflows/deploy.yml`) to automatically build the Vite project and deploy the `dist` folder contents to the `gh-pages` branch.
- This workflow triggers on pushes to the `main` branch.
- User has configured the `GEMINI_API_KEY` secret and GitHub Pages settings to serve from the `gh-pages` branch.