### PR TITLE
Fix: Ensure tour modal remains on top of highlighted elements

### DIFF
--- a/components/dashboard/GuidedTour.tsx
+++ b/components/dashboard/GuidedTour.tsx
@@ -120,7 +120,7 @@ export const GuidedTour: React.FC<GuidedTourProps> = ({
   }, [currentStep, isOpen, onStepChange, stepData]);
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-75 z-50 flex items-center justify-center p-4 transition-opacity duration-300">
+    <div className="fixed inset-0 bg-black bg-opacity-75 z-[150] flex items-center justify-center p-4 transition-opacity duration-300"> {/* Changed z-50 to z-[150] */}
       <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-2xl w-full max-w-md transform transition-all duration-300 scale-100">
         <div className="flex justify-between items-center mb-4">
           <h3 className="text-xl font-semibold text-gray-900 dark:text-white">{stepData.title}</h3>


### PR DESCRIPTION
Increased the z-index of the guided tour modal container to 150. This ensures it renders above highlighted page elements (which have a z-index of 100), preventing the tour card from being obscured and becoming unclickable.